### PR TITLE
Add support for algebraic datatypes

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -25,6 +25,8 @@ pub enum AstNode {
     LambdaNode(Vec<String>, Box<Ast>),
     /// (function_name, param_list, body)
     FunctionNode(String, Vec<String>, Box<Ast>),
+    // (data_name, data_Variants)
+    DataNode(String, Vec<(String, Vec<String>)>),
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -42,6 +44,7 @@ impl Ast {
         self.pretty_print_helper(0)
     }
 
+    // TODO: clean up pretty printer
     fn pretty_print_helper(&self, indent_level: usize) -> String {
         let content = match &self.node {
             AstNode::NumberNode(e) => format!("NumberNode({})", e),
@@ -95,6 +98,15 @@ impl Ast {
                 name,
                 params.join(", "),
                 body.pretty_print_helper(indent_level + 1)
+            ),
+            AstNode::DataNode(name, variants) => format!(
+                "DataNode(name: {}, variants: {})",
+                name,
+                variants
+                    .iter()
+                    .map(|(name, fields)| format!("{}({}) ", name, fields.join(", ")))
+                    .collect::<Vec<String>>()
+                    .join(" | "),
             ),
         };
         format!("\n{}{}", "\t".repeat(indent_level), content)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,7 +1,7 @@
 use im::HashMap;
 use std::{fmt, ops::Range, usize};
 
-pub type Env<'a> = HashMap<String, Val<'a>>;
+pub type Env = HashMap<String, Val>;
 pub type Program = Vec<Ast>;
 #[derive(PartialEq, Debug, Clone)]
 pub enum AstNode {
@@ -135,15 +135,15 @@ pub enum BinOp {
     Lt,
 }
 #[derive(PartialEq, Debug, Clone)]
-pub enum Val<'a> {
+pub enum Val {
     Num(i64),
     Bool(bool),
-    Lam(&'a Vec<String>, &'a Ast, Env<'a>),
+    Lam(Vec<String>, Ast, Env),
     // (discriminant, values)
-    Data(String, Vec<Val<'a>>),
+    Data(String, Vec<Val>),
 }
 
-impl<'a> fmt::Display for Val<'a> {
+impl fmt::Display for Val {
     // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/interpreter/interpret.rs
+++ b/src/interpreter/interpret.rs
@@ -143,6 +143,7 @@ fn interpret_expr<'a>(
             "Function node not at top level".to_string(),
             expr.src_loc.span.clone(),
         )),
+        AstNode::DataNode(_name, _variants) => panic!("Not yet implemented"),
     }
 }
 

--- a/src/lexer/lex.rs
+++ b/src/lexer/lex.rs
@@ -24,8 +24,12 @@ pub enum Token {
     Comma,
     #[token(":")]
     Colon,
+    #[token("|")]
+    Pipe,
     #[token("end")]
     End,
+    #[token("data")]
+    Data,
     #[token("let")]
     Let,
     #[token("if")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,10 @@ use structopt::StructOpt;
 /// The interpreter for the Skiff programming language
 #[derive(Debug, StructOpt)]
 struct Cli {
+    /// Stop after lexing
+    #[structopt(short = "l", long = "lex")]
+    stop_after_lexing: bool,
+
     /// Stop after parsing
     #[structopt(short = "p", long = "parse")]
     stop_after_parsing: bool,
@@ -33,6 +37,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let lexer = lex::Token::lexer(&raw);
 
     let mut token_vec: Vec<_> = lexer.spanned().collect();
+
+    if args.stop_after_lexing {
+        println!("{:?}", token_vec);
+        return Ok(());
+    }
 
     // Check for error tokens
     for (token, span) in &token_vec {

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -25,6 +25,7 @@ fn prefix_map(tok: &Token) -> Option<Box<dyn PrefixParselet>> {
         Token::If => Some(Box::new(IfParselet {})),
         Token::Let => Some(Box::new(LetParselet {})),
         Token::Def => Some(Box::new(FunctionParselet {})),
+        Token::Data => Some(Box::new(DataParselet {})),
         _ => None,
     }
 }

--- a/src/parser/parselets.rs
+++ b/src/parser/parselets.rs
@@ -347,7 +347,7 @@ impl PrefixParselet for DataParselet {
         };
 
         return Ok(Ast {
-            node: AstNode::DataNode(data_name, variants),
+            node: AstNode::DataDeclarationNode(data_name, variants),
             src_loc: SrcLoc {
                 span: span_start..span_end,
             },

--- a/src/parser/parselets.rs
+++ b/src/parser/parselets.rs
@@ -1,10 +1,10 @@
 use crate::ast::{Ast, AstNode, BinOp, SrcLoc};
 use crate::lexer::lex::Token;
-use crate::parser::parse;
+use crate::parser::parse::{self, parse_params};
 use crate::parser::util;
 use util::expect_and_consume;
 
-use super::util::ast_op_to_token_op;
+use super::util::{ast_op_to_token_op, consume_if_present};
 
 pub trait PrefixParselet {
     fn parse(
@@ -279,6 +279,79 @@ impl PrefixParselet for ParenthesisParselet {
         expect_and_consume(tokens, Token::RParen)?;
 
         return Ok(expr);
+    }
+}
+
+pub struct DataParselet {}
+impl PrefixParselet for DataParselet {
+    fn parse(
+        &self,
+        tokens: &mut Vec<(Token, std::ops::Range<usize>)>,
+        _current_token: (Token, std::ops::Range<usize>),
+        is_top_level: bool,
+    ) -> Result<Ast, util::ParseError> {
+        if !is_top_level {
+            return Err(util::ParseError(
+                "Data declarations can only exist at the top level".to_string(),
+            ));
+        }
+
+        let (data_name, span_start) = match tokens.pop() {
+            Some((Token::Identifier(id), span)) => Ok((id, span.start)),
+            Some(_) => Err(util::ParseError(
+                "Found non-identifier as data declaration name".to_string(),
+            )),
+            None => Err(util::ParseError(
+                "Ran out of tokens while parsing data declaration".to_string(),
+            )),
+        }?;
+
+        expect_and_consume(tokens, Token::Colon)?;
+        // Initial pipe character is optional
+        consume_if_present(tokens, Token::Pipe)?;
+
+        let mut variants = vec![];
+
+        let span_end = loop {
+            let variant_name = match tokens.pop() {
+                Some((Token::Identifier(id), _)) => Ok(id),
+                Some(_) => Err(util::ParseError(
+                    "Found non-identifier as data variant name".to_string(),
+                )),
+                None => Err(util::ParseError(
+                    "Ran out of tokens while parsing data variant".to_string(),
+                )),
+            }?;
+
+            // parse variant body
+            expect_and_consume(tokens, Token::LParen)?;
+            let field_names = parse_params(tokens)?;
+
+            variants.push((variant_name, field_names));
+
+            // Determine whether we have another variant to parse or if this is the end
+            match tokens.pop() {
+                Some((Token::Pipe, _)) => continue,
+                Some((Token::End, span)) => break span.end,
+                Some(_) => {
+                    return Err(util::ParseError(
+                        "Found bad token while parsing data variants".to_string(),
+                    ))
+                }
+                None => {
+                    return Err(util::ParseError(
+                        "Ran out of tokens while parsing data variant".to_string(),
+                    ))
+                }
+            }
+        };
+
+        return Ok(Ast {
+            node: AstNode::DataNode(data_name, variants),
+            src_loc: SrcLoc {
+                span: span_start..span_end,
+            },
+        });
     }
 }
 

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -31,6 +31,19 @@ pub fn expect_and_consume(
     match tokens.pop() {
         None => Err(ParseError("No tokens left to consume".to_string())),
         Some((v, span)) if v == expected => Ok(span),
-        _ => Err(ParseError("Didn't get expected token".to_string())),
+        Some((_, span)) => Err(ParseError(
+            format!("Didn't get expected token {:?} at {:?}", expected, span).to_string(),
+        )),
+    }
+}
+
+pub fn consume_if_present(
+    tokens: &mut Vec<(Token, std::ops::Range<usize>)>,
+    expected: Token,
+) -> Result<Option<(Token, std::ops::Range<usize>)>, ParseError> {
+    match tokens.last() {
+        None => Err(ParseError("No tokens left to consume".to_string())),
+        Some((v, _)) if v == &expected => Ok(Some(tokens.pop().unwrap())),
+        _ => Ok(None),
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,14 +6,19 @@ pub enum SimpleVal {
     Num(i64),
     Bool(bool),
     Lam(),
+    Data(String, Vec<SimpleVal>),
 }
 
 impl<'a> SimpleVal {
-    pub fn new(val: Val) -> SimpleVal {
+    pub fn new(val: &Val) -> SimpleVal {
         match val {
-            Val::Num(n) => SimpleVal::Num(n),
-            Val::Bool(b) => SimpleVal::Bool(b),
+            Val::Num(n) => SimpleVal::Num(*n),
+            Val::Bool(b) => SimpleVal::Bool(*b),
             Val::Lam(_, _, _) => SimpleVal::Lam(),
+            Val::Data(discriminant, fields) => SimpleVal::Data(
+                discriminant.clone(),
+                fields.iter().map(|x| SimpleVal::new(x)).collect(),
+            ),
         }
     }
 }
@@ -43,6 +48,13 @@ pub fn get_expected_output<'a>() -> HashMap<&'a str, Vec<SimpleVal>> {
         ("simple_bool.boat", vec![SimpleVal::Bool(false)]),
         ("simple_hof.skf", vec![SimpleVal::Num(3)]),
         ("simple_if.boat", vec![SimpleVal::Num(1)]),
+        (
+            "adt_simple.boat",
+            vec![
+                SimpleVal::Data("None".to_string(), vec![]),
+                SimpleVal::Data("Some".to_string(), vec![SimpleVal::Num(1)]),
+            ],
+        ),
     ]
     .iter()
     .cloned()

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -129,7 +129,7 @@ fn run_file<'a>(path: std::path::PathBuf) -> Result<Vec<SimpleVal>, TestError> {
     // Gather output
     let mut out = vec![];
     for val in output {
-        out.push(SimpleVal::new(val))
+        out.push(SimpleVal::new(&val))
     }
 
     return Ok(out);

--- a/tests/files/adt_simple.boat
+++ b/tests/files/adt_simple.boat
@@ -1,0 +1,8 @@
+data Option:
+    | Some(v)
+    | None()
+end 
+
+data T: Message(text) end
+
+data Tree: Leaf() | Node(left, val, right) end

--- a/tests/files/adt_simple.boat
+++ b/tests/files/adt_simple.boat
@@ -6,3 +6,7 @@ end
 data T: Message(text) end
 
 data Tree: Leaf() | Node(left, val, right) end
+
+None()
+
+Some(1)


### PR DESCRIPTION
This PR adds support for declaring algebraic datatypes with the `data` keyword. It also adds support for declaring variants of an ADT with the same syntax as a function call. No support is added for accessing fields of an ADT.