### PR TITLE
Add stack traces to error logging

### DIFF
--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -64,3 +64,13 @@ fn index_to_file_position(source: &str, index: usize) -> (usize, usize) {
 
     return (line, col);
 }
+
+/// Adds line and column info after a filename for printing
+pub fn add_position_info_to_filename(
+    source: &str,
+    index: usize,
+    filename: std::path::PathBuf,
+) -> String {
+    let (line, column) = index_to_file_position(source, index);
+    format!("{}:{}:{}", filename.display(), line, column)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,16 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let output = match interpret::interpret(&parsed) {
         Ok(output) => output,
-        Err(interpret::InterpError(msg, span, env)) => {
+        Err(interpret::InterpError(msg, span, env, stack)) => {
+            // print a stack trace
+            for (i, frame) in stack.iter().enumerate() {
+                println!("{}", frame.pretty_print(i, args.path.clone(), &raw));
+            }
+            // print the error message and source location
             error_handling::pretty_print_error(msg.borrow(), span, raw.borrow(), args.path);
-            println!("env: {:?}", env);
+            // print the environment
+            println!("Environment when error occured:\n\t{:?}", env);
+
             return Err(Box::new(SkiffError("Avast! Skiff execution failed")));
         }
     };

--- a/src/parser/parselets.rs
+++ b/src/parser/parselets.rs
@@ -456,11 +456,13 @@ impl PostfixParselet for FunCallParselet {
         left_node: Ast,
         _current_token: (Token, std::ops::Range<usize>),
     ) -> Result<Ast, util::ParseError> {
-        let args = parse::parse_args(tokens)?;
-        let span = left_node.src_loc.span.clone();
+        let (args, span_end) = parse::parse_args(tokens)?;
+        let span_start = left_node.src_loc.span.start;
         return Ok(Ast {
             node: AstNode::FunCallNode(Box::new(left_node), args),
-            src_loc: SrcLoc { span },
+            src_loc: SrcLoc {
+                span: span_start..span_end,
+            },
         });
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -73,10 +73,48 @@ pub fn get_expected_output<'a>() -> HashMap<&'a str, Vec<SimpleVal>> {
                 SimpleVal::Bool(true),
                 SimpleVal::Num(9),
                 SimpleVal::Num(9),
-                SimpleVal::Num(9),
             ],
         ),
         ("pattern_match_simple.boat", vec![SimpleVal::Num(2)]),
+        ("pattern_match_moderate.boat", vec![SimpleVal::Num(8)]),
+        (
+            "language_tour.boat",
+            vec![
+                SimpleVal::Data(
+                    "Link".to_string(),
+                    vec![
+                        SimpleVal::Num(2),
+                        SimpleVal::Data(
+                            "Link".to_string(),
+                            vec![
+                                SimpleVal::Num(3),
+                                SimpleVal::Data(
+                                    "Link".to_string(),
+                                    vec![
+                                        SimpleVal::Num(4),
+                                        SimpleVal::Data(
+                                            "Link".to_string(),
+                                            vec![
+                                                SimpleVal::Num(5),
+                                                SimpleVal::Data("Empty".to_string(), vec![]),
+                                            ],
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                SimpleVal::Data(
+                    "Link".to_string(),
+                    vec![
+                        SimpleVal::Num(2),
+                        SimpleVal::Data("Empty".to_string(), vec![]),
+                    ],
+                ),
+                SimpleVal::Num(10),
+            ],
+        ),
     ]
     .iter()
     .cloned()

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -116,7 +116,7 @@ fn run_file<'a>(path: std::path::PathBuf) -> Result<Vec<SimpleVal>, TestError> {
     // Interpret and check for errors
     let output = match interpret::interpret(&parsed) {
         Ok(output) => output,
-        Err(interpret::InterpError(msg, span, _)) => {
+        Err(interpret::InterpError(msg, span, _, _)) => {
             return Err(TestError {
                 message: msg,
                 span: Some(span),

--- a/tests/files/binops.boat
+++ b/tests/files/binops.boat
@@ -12,5 +12,4 @@
 true and true
 true or false
 11 & 9
-8 | 1
 3 ^ 10

--- a/tests/files/language_tour.boat
+++ b/tests/files/language_tour.boat
@@ -33,7 +33,7 @@ end
 
 def fold(func, l, default):
     match l:
-        | Link(f,r) => func(f, filter(func, r, default))
+        | Link(f,r) => func(f, fold(func, r, default))
         | Empty() => default
     end
 end


### PR DESCRIPTION
This PR adds stack frame tracking to the interpreter and a pretty printer for dumping the function call stack when an error occurs.