### PR TITLE
Add WASM library support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +83,16 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -106,6 +134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +153,15 @@ name = "libc"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "logos"
@@ -205,6 +251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,9 +271,12 @@ name = "skiff"
 version = "0.1.0"
 dependencies = [
  "colored",
+ "console_error_panic_hook",
  "im",
  "logos",
  "structopt",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -315,6 +370,106 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cab416a9b970464c2882ed92d55b0c33046b08e0bdc9d59b3b718acd4e1bae8"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4543fc6cf3541ef0d98bf720104cc6bd856d7eba449fd2aa365ef4fed0e782"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.wasm.toml
+++ b/Cargo.wasm.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [features]
 default = ["console_error_panic_hook"]
 
-# [lib]
-# crate-type = ["cdylib"]
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 logos = "0.12.0"
@@ -26,6 +26,6 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
 
-# [profile.release]
-# # Tell `rustc` to optimize for small code size.
-# opt-level = "s"
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -49,7 +49,7 @@ pub fn pretty_print_error(
 }
 
 /// Converts an index into a string into a line/column pair for that same string
-fn index_to_file_position(source: &str, index: usize) -> (usize, usize) {
+pub fn index_to_file_position(source: &str, index: usize) -> (usize, usize) {
     let mut line = 0;
     let mut last_newline_index = 0;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,8 @@ pub mod parser {
 pub mod interpreter {
     pub mod interpret;
 }
+
+pub mod wasm {
+    mod utils;
+    pub mod wasm_exports;
+}

--- a/src/wasm/skiffInterop.js
+++ b/src/wasm/skiffInterop.js
@@ -1,0 +1,4 @@
+export function writeTermLn(s) {
+  window.writeToTerm(s);
+  return true;
+}

--- a/src/wasm/utils.rs
+++ b/src/wasm/utils.rs
@@ -1,0 +1,10 @@
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}

--- a/src/wasm/wasm_exports.rs
+++ b/src/wasm/wasm_exports.rs
@@ -1,0 +1,159 @@
+use crate::{ast, error_handling, interpreter::interpret, lexer::lex, parser, parser::parse};
+use logos::Logos;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::{borrow::Borrow, error};
+use wasm_bindgen::prelude::*;
+
+use colored::*;
+use std::ops::Range;
+
+// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
+// allocator.
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+#[wasm_bindgen(module = "/src/wasm/skiffInterop.js")]
+extern "C" {
+    fn writeTermLn(s: &str) -> bool;
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+
+    #[wasm_bindgen(js_namespace = console)]
+    fn error(s: &str);
+}
+
+/// Prints an error message along with the location in the source file where the error occurred
+#[wasm_bindgen]
+pub fn wasm_pretty_print_error(
+    message: &str,
+    span_start: usize,
+    span_end: usize,
+    source: &str,
+    filename: &str,
+) -> () {
+    let span = span_start..span_end;
+    let filename = PathBuf::from_str(filename).unwrap();
+    return wasm_pretty_print_error_helper(message, span, source, filename);
+}
+
+pub fn wasm_pretty_print_error_helper(
+    message: &str,
+    span: Range<usize>,
+    source: &str,
+    filename: PathBuf,
+) -> () {
+    // Find the start and end of the error as line/col pair.
+    let (start_line, start_col) = error_handling::index_to_file_position(source, span.start);
+    let (end_line, end_col) = error_handling::index_to_file_position(source, span.end);
+
+    let lines: Vec<_> = source.split("\n").collect();
+
+    // let the user know there has been an error
+    unsafe {
+        writeTermLn(&format!("ERROR in {:?}: {}", filename, message));
+    }
+
+    // Print the error location
+    for i in start_line..(end_line + 1) {
+        // print the line from the source file
+        unsafe {
+            writeTermLn(&format!("{:4} {} {}", i + 1, "|".blue().bold(), lines[i]));
+        }
+
+        // print the error underline (some amount of blank followed by the underline)
+        let blank_size;
+        let underline_size;
+        if i == start_line && i == end_line {
+            blank_size = start_col;
+            underline_size = end_col - start_col;
+        } else if i == start_line {
+            blank_size = start_col;
+            underline_size = lines[i].chars().count() - start_col;
+        } else if i == end_line {
+            blank_size = 0;
+            underline_size = end_col;
+        } else {
+            blank_size = 0;
+            underline_size = lines[i].chars().count();
+        }
+        unsafe {
+            writeTermLn(&format!(
+                "{:4} {} {}{}",
+                "",
+                "|".blue().bold(),
+                " ".repeat(blank_size),
+                "^".repeat(underline_size).red().bold()
+            ));
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub fn evaluate(raw: &str) -> () {
+    let filename = "main.boat";
+    let lexer = lex::Token::lexer(&raw);
+
+    let mut token_vec: Vec<_> = lexer.spanned().collect();
+
+    // Check for error tokens
+    for (token, span) in &token_vec {
+        if token == &lex::Token::Error {
+            wasm_pretty_print_error(
+                "Invalid token",
+                span.start,
+                span.end,
+                raw.borrow(),
+                filename,
+            );
+            return;
+        }
+    }
+
+    token_vec.reverse();
+
+    let parsed = match parse::parse_program(&mut token_vec) {
+        Ok(program) => program,
+        Err(parser::util::ParseError(msg, Some(span))) => {
+            wasm_pretty_print_error(msg.borrow(), span.start, span.end, raw.borrow(), filename);
+            return;
+        }
+        Err(parser::util::ParseError(msg, None)) => {
+            wasm_pretty_print_error(msg.borrow(), 0, 0, raw.borrow(), filename);
+            return;
+        }
+    };
+
+    let output = match interpret::interpret(&parsed) {
+        Ok(output) => output,
+        Err(interpret::InterpError(msg, span, env, stack)) => {
+            // print a stack trace
+            for (i, frame) in stack.iter().enumerate() {
+                unsafe {
+                    writeTermLn(&format!(
+                        "{}",
+                        frame.pretty_print(i, PathBuf::from_str(filename.clone()).unwrap(), &raw)
+                    ));
+                }
+            }
+            // print the error message and source location
+            wasm_pretty_print_error(msg.borrow(), span.start, span.end, raw.borrow(), filename);
+            // print the environment
+            unsafe {
+                writeTermLn(&format!("Environment when error occurred:\n\t{:?}", env));
+            }
+            return;
+        }
+    };
+
+    for val in output {
+        unsafe {
+            writeTermLn(&format!("{}", val));
+        }
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -78,6 +78,15 @@ pub fn get_expected_output<'a>() -> HashMap<&'a str, Vec<SimpleVal>> {
         ("pattern_match_simple.boat", vec![SimpleVal::Num(2)]),
         ("pattern_match_moderate.boat", vec![SimpleVal::Num(8)]),
         (
+            "singles.boat",
+            vec![
+                SimpleVal::Bool(true),
+                SimpleVal::Bool(true),
+                SimpleVal::Bool(true),
+                SimpleVal::Bool(true),
+            ],
+        ),
+        (
             "language_tour.boat",
             vec![
                 SimpleVal::Data(

--- a/tests/files/singles.boat
+++ b/tests/files/singles.boat
@@ -1,0 +1,42 @@
+data List:
+	| link(first,rest)
+	| empty()
+end
+let mt = empty()
+
+data Option:
+    | some(v)
+    | none()
+end
+
+def singles(lst, to_replace):
+    match to_replace:
+        | some(v) => 
+            match lst:
+                | link(f,r) => 
+                    if f == v:
+                        singles(r, to_replace)
+                    else:
+                        link(f, singles(r, some(f)))
+                    end
+                | empty() => empty()
+            end
+        | none() =>
+            match lst:
+                | link(f,r) => link(f, singles(r, some(f)))
+                | empty() => empty()
+            end
+    end
+end
+
+let one_through_four = link(1,link(2,link(3,link(4,mt))))
+let with_dups1 = link(1,link(1,link(2,link(2,link(3,link(4,mt))))))
+let with_dups2 = link(1,link(2,link(3,link(3,link(3,link(4,mt))))))
+
+singles(mt, none()) == mt
+
+singles(one_through_four, none()) == one_through_four
+
+singles(with_dups1, none()) == one_through_four
+
+singles(with_dups2, none()) == one_through_four

--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -1,0 +1,8 @@
+mv Cargo.toml Cargo.desktop.toml
+mv Cargo.wasm.toml Cargo.toml
+~/.cargo/bin/wasm-pack build
+mv Cargo.toml Cargo.wasm.toml
+mv Cargo.desktop.toml Cargo.toml
+echo ""
+echo "Package built"
+echo "Remember to update name, version, and add snippets directory"


### PR DESCRIPTION
Adds support for exporting skiff runtime as a wasm library. Relies on having global `window.writeToTerm` available in JS. `wasm_build.sh` script provided to make `wasm-pack` usage seamless.