### PR TITLE
Add exhaustiveness checking

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -262,6 +262,28 @@ pub enum Pattern {
     Identifier(String),
 }
 
+impl Pattern {
+    /// Returns `true` if the pattern is [`NumLiteral`].
+    pub fn is_num_literal(&self) -> bool {
+        matches!(self, Self::NumLiteral(..))
+    }
+
+    /// Returns `true` if the pattern is [`BoolLiteral`].
+    pub fn is_bool_literal(&self) -> bool {
+        matches!(self, Self::BoolLiteral(..))
+    }
+
+    /// Returns `true` if the pattern is [`Data`].
+    pub fn is_data(&self) -> bool {
+        matches!(self, Self::Data(..))
+    }
+
+    /// Returns `true` if the pattern is [`Identifier`].
+    pub fn is_identifier(&self) -> bool {
+        matches!(self, Self::Identifier(..))
+    }
+}
+
 #[derive(PartialEq, Debug, Clone, Copy, Hash)]
 pub enum BinOp {
     Plus,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -227,6 +227,53 @@ impl Ast {
             content
         )
     }
+
+    pub fn into_vec(&self) -> Vec<&Ast> {
+        let mut out = vec![self];
+        match &self.node {
+            AstNode::NumberNode(_) | AstNode::BoolNode(_) | AstNode::VarNode(_) => (),
+            // Add the let binding to the environment and then interpret the body
+            AstNode::LetNode(_, binding, body) => {
+                out.extend(binding.into_vec());
+                out.extend(body.into_vec());
+            }
+            AstNode::LetNodeTopLevel(_, binding) => out.extend(binding.into_vec()),
+            AstNode::BinOpNode(_, e1, e2) => {
+                out.extend(e1.into_vec());
+                out.extend(e2.into_vec());
+            }
+            AstNode::LambdaNode(_, body) => out.extend(body.into_vec()),
+            AstNode::FunCallNode(fun, args) => {
+                out.extend(fun.into_vec());
+                for arg in args {
+                    out.extend(arg.into_vec());
+                }
+            }
+            AstNode::IfNode(conditions_and_bodies, alternate) => {
+                for (condition, body) in conditions_and_bodies {
+                    out.extend(condition.into_vec());
+                    out.extend(body.into_vec());
+                }
+                out.extend(alternate.into_vec());
+            }
+            AstNode::FunctionNode(_, _, _, body) => {
+                out.extend(body.into_vec());
+            }
+            AstNode::DataDeclarationNode(_, _) => (),
+            AstNode::DataLiteralNode(_, fields) => {
+                for field in fields {
+                    out.extend(field.into_vec());
+                }
+            }
+            AstNode::MatchNode(expression_to_match, branches) => {
+                out.extend(expression_to_match.into_vec());
+                for (_, expr) in branches {
+                    out.extend(expr.into_vec());
+                }
+            }
+        };
+        return out;
+    }
 }
 
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Default)]

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -1,12 +1,32 @@
 use colored::*;
 use std::ops::Range;
 
-/// Prints an error message along with the location in the source file where the error occurred
 pub fn pretty_print_error(
     message: &str,
     span: Range<usize>,
     source: &str,
     filename: std::path::PathBuf,
+) -> () {
+    pretty_print_diagnostic(message, span, source, filename, "ERROR", Color::Red);
+}
+
+pub fn pretty_print_warning(
+    message: &str,
+    span: Range<usize>,
+    source: &str,
+    filename: std::path::PathBuf,
+) -> () {
+    pretty_print_diagnostic(message, span, source, filename, "WARNING", Color::Yellow);
+}
+
+/// Prints an error message along with the location in the source file where the error occurred
+fn pretty_print_diagnostic(
+    message: &str,
+    span: Range<usize>,
+    source: &str,
+    filename: std::path::PathBuf,
+    diagnostic_type: &str,
+    color: Color,
 ) -> () {
     // Find the start and end of the error as line/col pair.
     let (start_line, start_col) = index_to_file_position(source, span.start);
@@ -15,7 +35,12 @@ pub fn pretty_print_error(
     let lines: Vec<_> = source.split("\n").collect();
 
     // let the user know there has been an error
-    println!("ERROR in {:?}: {}", filename, message);
+    println!(
+        "{} in {:?}: {}",
+        diagnostic_type.color(color),
+        filename,
+        message
+    );
 
     // Print the error location
     for i in start_line..(end_line + 1) {
@@ -46,7 +71,7 @@ pub fn pretty_print_error(
             "",
             "|".blue().bold(),
             " ".repeat(blank_size),
-            "^".repeat(underline_size).red().bold()
+            "^".repeat(underline_size).color(color).bold()
         );
     }
 }
@@ -76,7 +101,7 @@ pub fn index_to_file_position(source: &str, index: usize) -> (usize, usize) {
 pub fn add_position_info_to_filename(
     source: &str,
     index: usize,
-    filename: std::path::PathBuf,
+    filename: &std::path::PathBuf,
 ) -> String {
     let (line, column) = index_to_file_position(source, index);
     format!("{}:{}:{}", filename.display(), line, column)

--- a/src/interpreter/interpret.rs
+++ b/src/interpreter/interpret.rs
@@ -42,7 +42,7 @@ impl StackFrame {
     pub fn pretty_print(
         &self,
         stack_index: usize,
-        filename: std::path::PathBuf,
+        filename: &std::path::PathBuf,
         source: &str,
     ) -> String {
         match self {
@@ -56,6 +56,13 @@ impl StackFrame {
                 source[span.start..span.end].to_string(),
             )
             .to_string(),
+        }
+    }
+
+    pub fn print_stack(stack: &Vector<Self>, filename: &std::path::PathBuf, source: &str) -> () {
+        println!("Printing stack trace (most recent call last)");
+        for (i, frame) in stack.iter().enumerate() {
+            println!("{}", frame.pretty_print(i, filename, source));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,3 +35,7 @@ pub mod wasm {
     mod utils;
     pub mod wasm_exports;
 }
+
+pub mod static_checking {
+    mod exhaustiveness;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,5 +37,5 @@ pub mod wasm {
 }
 
 pub mod static_checking {
-    mod exhaustiveness;
+    pub mod exhaustiveness;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use colored::*;
 use logos::Logos;
+use skiff::error_handling::pretty_print_warning;
+use skiff::interpreter::interpret::StackFrame;
 use skiff::static_checking::exhaustiveness::{
     check_program_exhaustiveness, ProgramExhaustivenessReport,
 };
@@ -128,12 +130,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         Ok(ProgramExhaustivenessReport {
             non_exhaustive_matches,
         }) => {
-            for non_exhaustive_match in non_exhaustive_matches {
-                println!(
-                    "{} {:?}",
-                    "Non-exhaustive match:".bright_yellow().bold(),
-                    non_exhaustive_match
-                );
+            for match_loc in non_exhaustive_matches {
+                pretty_print_warning(
+                    "Non-exhaustive match expression",
+                    match_loc.span,
+                    raw.borrow(),
+                    args.path.clone(),
+                )
             }
         }
         Err(e) => {
@@ -145,14 +148,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let output = match interpret::interpret(&parsed_with_anys) {
         Ok(output) => output,
         Err(interpret::InterpError(msg, span, env, stack)) => {
-            // print a stack trace
-            for (i, frame) in stack.iter().enumerate() {
-                println!("{}", frame.pretty_print(i, args.path.clone(), &raw));
-            }
             // print the error message and source location
-            error_handling::pretty_print_error(msg.borrow(), span, raw.borrow(), args.path);
+            error_handling::pretty_print_error(msg.borrow(), span, raw.borrow(), args.path.clone());
+            // print a stack trace
+            StackFrame::print_stack(&stack, &args.path, raw.borrow());
             // print the environment
-            println!("Environment when error occured:\n\t{:?}", env);
+            println!("Environment when error occured:\n{:?}", env);
 
             return Err(Box::new(SkiffError("Avast! Skiff execution failed")));
         }

--- a/src/static_checking/exhaustiveness.rs
+++ b/src/static_checking/exhaustiveness.rs
@@ -1,0 +1,339 @@
+use std::collections::HashMap;
+
+use crate::ast::{Pattern, Type, Val};
+
+#[derive(PartialEq, Debug, Clone, Hash)]
+pub enum ExhaustivenessError {
+    UnknownTypeToMatchOn(),
+    UnknownTypeVariant(),
+    CantMatchFunction(),
+    CantMatchAny(),
+    NotEnoughArgsInPattern(),
+    TooManyArgsInPattern(),
+}
+
+type TypeTable = HashMap<String, Vec<(String, Vec<Type>)>>;
+
+pub fn check_pattern_exhaustiveness<'a>(
+    target_type: &Type,
+    patterns: &Vec<Pattern>,
+    type_table: &TypeTable,
+) -> Result<bool, ExhaustivenessError> {
+    match target_type {
+        Type { id, .. } if id == "Number" => {
+            if patterns.iter().any(|x| x.is_identifier()) {
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+        Type { id, .. } if id == "Boolean" => {
+            if patterns.iter().any(|x| x.is_identifier())
+                || (patterns.iter().any(|x| *x == Pattern::BoolLiteral(true))
+                    && patterns.iter().any(|x| *x == Pattern::BoolLiteral(false)))
+            {
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+        Type { id, .. } if id == "Function" => Err(ExhaustivenessError::CantMatchFunction()),
+        Type { id, .. } if id == "Any" => Err(ExhaustivenessError::CantMatchAny()),
+        Type { id, .. } => {
+            if patterns.iter().any(|x| x.is_identifier()) {
+                Ok(true)
+            } else {
+                if let Some(variants) = type_table.get(id) {
+                    for (variant_name, variant_types) in variants {
+                        let args_of_valid_patterns: Vec<&Vec<Pattern>> = patterns
+                            .iter()
+                            .filter_map(|pattern| match pattern {
+                                Pattern::Data(name, pattern_args) => {
+                                    if name == variant_name {
+                                        Some(pattern_args)
+                                    } else {
+                                        None
+                                    }
+                                }
+                                _ => None,
+                            })
+                            .collect();
+
+                        // If there aren't any patterns that match this variant then the match is not exhaustive
+                        if args_of_valid_patterns.len() == 0 {
+                            return Ok(false);
+                        }
+
+                        for (i, type_arg) in variant_types.iter().enumerate() {
+                            let args_for_this_match: Vec<&Pattern> = args_of_valid_patterns
+                                .iter()
+                                .map(|pattern_args| match pattern_args.get(i) {
+                                    Some(v) => Ok(v),
+                                    None => Err(ExhaustivenessError::NotEnoughArgsInPattern()),
+                                })
+                                .collect::<Result<Vec<&Pattern>, ExhaustivenessError>>()?;
+
+                            if check_pattern_exhaustiveness(
+                                type_arg,
+                                &args_for_this_match.into_iter().cloned().collect(),
+                                type_table,
+                            )? {
+                                continue;
+                            } else {
+                                return Ok(false);
+                            }
+                        }
+                    }
+                    return Ok(true);
+                } else {
+                    Err(ExhaustivenessError::UnknownTypeToMatchOn())
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod exhaustiveness_tests {
+    use im::vector;
+
+    use super::*;
+
+    #[test]
+    fn fails_baseline_number_without_identifier() {
+        let input_type = Type::new_number();
+        let input_patterns: Vec<Pattern> = vec![Pattern::NumLiteral(1), Pattern::NumLiteral(2)];
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &HashMap::new());
+        let expected_output = Ok(false);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn passes_baseline_number_with_identifier() {
+        let input_type = Type::new_number();
+        let input_patterns: Vec<Pattern> = vec![
+            Pattern::NumLiteral(1),
+            Pattern::NumLiteral(2),
+            Pattern::Identifier("foo".to_string()),
+        ];
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &HashMap::new());
+        let expected_output = Ok(true);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn fails_baseline_boolean() {
+        let input_type = Type::new_boolean();
+        let input_patterns: Vec<Pattern> = vec![Pattern::BoolLiteral(true)];
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &HashMap::new());
+        let expected_output = Ok(false);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn passes_baseline_boolean_without_identifier() {
+        let input_type = Type::new_boolean();
+        let input_patterns: Vec<Pattern> =
+            vec![Pattern::BoolLiteral(true), Pattern::BoolLiteral(false)];
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &HashMap::new());
+        let expected_output = Ok(true);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn passes_baseline_boolean_with_identifier() {
+        let input_type = Type::new_boolean();
+        let input_patterns: Vec<Pattern> = vec![Pattern::Identifier("_".to_string())];
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &HashMap::new());
+        let expected_output = Ok(true);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn fails_option_type_if_no_none() {
+        let input_type = Type::new("Option".to_string(), vector![]);
+        let input_patterns: Vec<Pattern> = vec![
+            Pattern::Data("some".to_string(), vec![Pattern::NumLiteral(10)]),
+            Pattern::Data("some".to_string(), vec![Pattern::NumLiteral(20)]),
+            Pattern::Data(
+                "some".to_string(),
+                vec![Pattern::Identifier("_".to_string())],
+            ),
+        ];
+        let type_table: TypeTable = vec![(
+            "Option".to_string(),
+            vec![
+                ("some".to_string(), vec![Type::new_number()]),
+                ("none".to_string(), vec![]),
+            ],
+        )]
+        .into_iter()
+        .collect();
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &type_table);
+        let expected_output = Ok(false);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn errors_on_not_enough_pattern_args_for_option() {
+        let input_type = Type::new("Option".to_string(), vector![]);
+        let input_patterns: Vec<Pattern> = vec![Pattern::Data("some".to_string(), vec![])];
+        let type_table: TypeTable = vec![(
+            "Option".to_string(),
+            vec![
+                ("some".to_string(), vec![Type::new_number()]),
+                ("none".to_string(), vec![]),
+            ],
+        )]
+        .into_iter()
+        .collect();
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &type_table);
+        let expected_output = Err(ExhaustivenessError::NotEnoughArgsInPattern());
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn passes_option_type_with_wildcard_identifier() {
+        let input_type = Type::new("Option".to_string(), vector![]);
+        let input_patterns: Vec<Pattern> = vec![Pattern::Identifier("_".to_string())];
+        let type_table: TypeTable = vec![(
+            "Option".to_string(),
+            vec![
+                ("some".to_string(), vec![Type::new_number()]),
+                ("none".to_string(), vec![]),
+            ],
+        )]
+        .into_iter()
+        .collect();
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &type_table);
+        let expected_output = Ok(true);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn fails_option_type_if_no_identifier() {
+        let input_type = Type::new("Option".to_string(), vector![]);
+        let input_patterns: Vec<Pattern> = vec![
+            Pattern::Data("some".to_string(), vec![Pattern::NumLiteral(10)]),
+            Pattern::Data("some".to_string(), vec![Pattern::NumLiteral(20)]),
+            Pattern::Data("none".to_string(), vec![Pattern::BoolLiteral(false)]),
+        ];
+        let type_table: TypeTable = vec![(
+            "Option".to_string(),
+            vec![
+                ("some".to_string(), vec![Type::new_number()]),
+                ("none".to_string(), vec![]),
+            ],
+        )]
+        .into_iter()
+        .collect();
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &type_table);
+        let expected_output = Ok(false);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn passes_option_type_with_identifier() {
+        let input_type = Type::new("Option".to_string(), vector![]);
+        let input_patterns: Vec<Pattern> = vec![
+            Pattern::Data("some".to_string(), vec![Pattern::NumLiteral(10)]),
+            Pattern::Data("some".to_string(), vec![Pattern::NumLiteral(20)]),
+            Pattern::Data(
+                "some".to_string(),
+                vec![Pattern::Identifier("_".to_string())],
+            ),
+            Pattern::Data("none".to_string(), vec![Pattern::BoolLiteral(false)]),
+        ];
+        let type_table: TypeTable = vec![(
+            "Option".to_string(),
+            vec![
+                ("some".to_string(), vec![Type::new_number()]),
+                ("none".to_string(), vec![]),
+            ],
+        )]
+        .into_iter()
+        .collect();
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &type_table);
+        let expected_output = Ok(true);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn fails_complex_bool_nesting() {
+        let input_type = Type::new("MaybeBools".to_string(), vector![]);
+        let input_patterns: Vec<Pattern> = vec![
+            Pattern::Data("one".to_string(), vec![Pattern::BoolLiteral(true)]),
+            Pattern::Data("one".to_string(), vec![Pattern::BoolLiteral(false)]),
+            Pattern::Data(
+                "two".to_string(),
+                vec![Pattern::BoolLiteral(false), Pattern::BoolLiteral(false)],
+            ),
+            Pattern::Data(
+                "two".to_string(),
+                vec![Pattern::BoolLiteral(true), Pattern::BoolLiteral(false)],
+            ),
+        ];
+        let type_table: TypeTable = vec![(
+            "MaybeBools".to_string(),
+            vec![
+                ("one".to_string(), vec![Type::new_boolean()]),
+                (
+                    "two".to_string(),
+                    vec![Type::new_boolean(), Type::new_boolean()],
+                ),
+            ],
+        )]
+        .into_iter()
+        .collect();
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &type_table);
+        let expected_output = Ok(false);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn passes_complex_bool_nesting() {
+        let input_type = Type::new("MaybeBools".to_string(), vector![]);
+        let input_patterns: Vec<Pattern> = vec![
+            Pattern::Data("one".to_string(), vec![Pattern::BoolLiteral(true)]),
+            Pattern::Data("one".to_string(), vec![Pattern::BoolLiteral(false)]),
+            Pattern::Data(
+                "two".to_string(),
+                vec![Pattern::BoolLiteral(false), Pattern::BoolLiteral(false)],
+            ),
+            Pattern::Data(
+                "two".to_string(),
+                vec![
+                    Pattern::BoolLiteral(true),
+                    Pattern::Identifier("_".to_string()),
+                ],
+            ),
+        ];
+        let type_table: TypeTable = vec![(
+            "MaybeBools".to_string(),
+            vec![
+                ("one".to_string(), vec![Type::new_boolean()]),
+                (
+                    "two".to_string(),
+                    vec![Type::new_boolean(), Type::new_boolean()],
+                ),
+            ],
+        )]
+        .into_iter()
+        .collect();
+
+        let result = check_pattern_exhaustiveness(&input_type, &input_patterns, &type_table);
+        let expected_output = Ok(true);
+        assert_eq!(result, expected_output);
+    }
+}

--- a/src/static_checking/exhaustiveness.rs
+++ b/src/static_checking/exhaustiveness.rs
@@ -70,7 +70,6 @@ pub fn check_program_exhaustiveness(
         for expr in statement.into_vec() {
             match &expr.node {
                 AstNode::MatchNode(target, branches) => {
-                    println!("Found match node");
                     if let Some(term) = type_table.get(&target.label) {
                         if let Some(t) = term.clone().into_type() {
                             let is_exhaustive = check_pattern_exhaustiveness(
@@ -102,10 +101,6 @@ pub fn check_pattern_exhaustiveness<'a>(
     patterns: &Vec<Pattern>,
     data_table: &DataTable,
 ) -> Result<bool, ExhaustivenessError> {
-    println!(
-        "Checking {:?}, {:?}, {:?},",
-        target_type, patterns, data_table
-    );
     match target_type {
         Type { id, .. } if id == "Number" => {
             if patterns.iter().any(|x| x.is_identifier()) {

--- a/src/type_inferencer/ast.rs
+++ b/src/type_inferencer/ast.rs
@@ -82,6 +82,18 @@ impl Term {
             t.args.iter().map(|t| Term::from_type(t)).collect(),
         )
     }
+    pub fn into_type(self) -> Option<Type> {
+        match self {
+            Term::Var(_) => None,
+            Term::Constructor(id, args) => {
+                if let Some(args) = args.into_iter().map(|arg| arg.into_type()).collect() {
+                    Some(Type::new(id.to_string(), args))
+                } else {
+                    None
+                }
+            }
+        }
+    }
     pub fn new_var() -> Self {
         Term::Var(gensym())
     }

--- a/src/type_inferencer/type_inference.rs
+++ b/src/type_inferencer/type_inference.rs
@@ -22,9 +22,12 @@ pub enum InferenceError {
     DataDeclarationError(InterpError),
 }
 
-pub fn infer_types(program: &Program) -> Result<SubstitutionSet, InferenceError> {
+pub fn infer_types(
+    program: &Program,
+    data_decl_table: &DataDeclTable,
+) -> Result<SubstitutionSet, InferenceError> {
     // println!("PROGRAM: {:?}", program);
-    let constraint_set = generate_constraints(&program)?;
+    let constraint_set = generate_constraints(&program, data_decl_table)?;
     // println!("CONSTRAINTS: {:?}", constraint_set);
     let substition_set = unify_constraints(constraint_set)?;
     Ok(substition_set)

--- a/src/wasm/wasm_exports.rs
+++ b/src/wasm/wasm_exports.rs
@@ -134,7 +134,7 @@ pub fn evaluate(raw: &str) -> () {
             for (i, frame) in stack.iter().enumerate() {
                 writeTermLn(&format!(
                     "{}",
-                    frame.pretty_print(i, PathBuf::from_str(filename.clone()).unwrap(), &raw)
+                    frame.pretty_print(i, &PathBuf::from_str(filename.clone()).unwrap(), &raw)
                 ));
             }
             // print the error message and source location

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -1,6 +1,7 @@
 mod common;
 use common::SimpleVal;
 use logos::Logos;
+use skiff::type_inferencer::constraint_gen::find_types;
 use skiff::type_inferencer::type_inference::{self, InferenceError};
 use skiff::type_inferencer::util::add_any_to_declarations;
 use skiff::{error_handling, interpreter::interpret, lexer::lex, parser::parse};
@@ -146,7 +147,9 @@ fn run_file<'a>(path: std::path::PathBuf) -> Result<Vec<SimpleVal>, TestError> {
 
     let parsed_with_anys = add_any_to_declarations(parsed);
 
-    match type_inference::infer_types(&parsed_with_anys) {
+    let data_decl_table = find_types(&parsed_with_anys);
+
+    match type_inference::infer_types(&parsed_with_anys, &data_decl_table) {
         Err(InferenceError::ConstructorMismatch(t1, t2)) => {
             return Err(TestError {
                 message: format!("Type mismatch: {} is not {}", t1, t2),

--- a/tests/files/error/match_non_exhaustive.boat
+++ b/tests/files/error/match_non_exhaustive.boat
@@ -1,0 +1,8 @@
+data Option:
+    | some(v)
+    | none()
+end
+
+match some(1):
+    | none() => 1
+end


### PR DESCRIPTION
Adds exhaustiveness checking for match statements which have a known (or inferred) type. Failures are logged as warnings but allow execution to continue.